### PR TITLE
Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ end
 # In an IEx session
 Sample.Bot.converse("Hello World")
 iex> {:ok,
- %Automaton.Conversation.Message{receipient: :console, sender: Sample.Bot,
+ %Automaton.Conversation.Message{recipient: :console, sender: Sample.Bot,
   sent_at: 1499264553, session_id: {Sample.Bot, :console}, text: "Hello World"}}
 ```
 

--- a/lib/automaton.ex
+++ b/lib/automaton.ex
@@ -23,7 +23,7 @@ defmodule Automaton do
   Bot's receive callback. Parses the message and starts a conversation
   """
   def receive(message, bot, adapter) do
-    with {:ok, parsed_message} <- parse_and_set_receipient(message, bot, adapter),
+    with {:ok, parsed_message} <- parse_and_set_recipient(message, bot, adapter),
          {:ok, message} <- Conversation.add_message(parsed_message, bot) do
       {:ok, message}
     else
@@ -43,9 +43,9 @@ defmodule Automaton do
     end
   end
 
-  defp parse_and_set_receipient(message, bot, adapter) do
+  defp parse_and_set_recipient(message, bot, adapter) do
     with {:ok, parsed_message} <- adapter.parse(message) do
-      {:ok, %{parsed_message | receipient: bot}}
+      {:ok, %{parsed_message | recipient: bot}}
     end
   end
 end

--- a/lib/automaton/brains/echo.ex
+++ b/lib/automaton/brains/echo.ex
@@ -6,8 +6,8 @@ defmodule Automaton.Brains.Echo do
 
   alias Automaton.Conversation.Message
 
-  def process(%Message{text: text, receipient: receipient, sender: sender} = message, _config) do
-    {:ok, %{message | text: text, receipient: sender, sender: receipient}}
+  def process(%Message{text: text, recipient: recipient, sender: sender} = message, _config) do
+    {:ok, %{message | text: text, recipient: sender, sender: recipient}}
   end
 
 end

--- a/lib/automaton/conversation/message.ex
+++ b/lib/automaton/conversation/message.ex
@@ -5,7 +5,7 @@ defmodule Automaton.Conversation.Message do
 
   defstruct session_id: nil,
             sender: nil,
-            receipient: nil,
+            recipient: nil,
             text: "",
             sent_at: nil
 end


### PR DESCRIPTION
`Receipient` should be spelled `recipient`.